### PR TITLE
fix: missing index.d.ts breaks minor version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@datalogui/datalog",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "(MIT OR Apache-2.0)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist/index.js",
+    "dist/index.d.ts",
     "dist/datalog.js",
     "dist/datalog.d.ts",
     "dist/view-ext.js",


### PR DESCRIPTION
I noticed this package is missing it's index.d.ts file, this seems to break npm installing and using the package from within typescript. 

The fix seemed to be just including it within the files list. This was tested just using npm pack and then installing the packaged file.